### PR TITLE
Defining a define library. So we can re-use the code somewhere else

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,14 @@ name = "define"
 version = "0.1.0"
 authors = ["Guilherme Reis Campos <guilhermekbsa@gmail.com>"]
 
+[lib]
+name = "define"
+path = "src/lib.rs"
+
+[[bin]]
+name = "define"
+path = "src/main.rs"
+
 [dependencies]
 hyper = "0.10.9"
 serde_json = "1.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 extern crate serde_json;
+extern crate define;
 use std::env;
 use std::process;
+use define::dictionaries;
 
 use serde_json::{Value};
-
-mod dictionaries;
 
 fn main() {
   let args: Vec<_> = env::args().collect();
@@ -28,6 +28,4 @@ fn main() {
       }
     }
   }
-  println!("{}", body);
-
 }


### PR DESCRIPTION
Using a different way to import the domain of the application into the main program. By doing so, all the domain of the application becomes exportable as a lib. Thus, who wants to use specific parts of define can do it. 👍 